### PR TITLE
remove box resizer in run_update_volume

### DIFF
--- a/jankflow/base/simulation.py
+++ b/jankflow/base/simulation.py
@@ -697,6 +697,7 @@ class Simulation(hoomd.simulation.Simulation):
         self.operations.updaters.append(std_out_logger_printer)
         self.run(steps=n_steps + 1, write_at_start=write_at_start)
         self.operations.updaters.remove(std_out_logger_printer)
+        self.operations.updaters.remove(box_resizer)
 
     def run_langevin(
         self,


### PR DESCRIPTION
Fixes a bug where the box resizer isn't being removed from operations. This was causing issues when running NPT simulations after using `run_update_volume`